### PR TITLE
Add Dayzed datepicker

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ changes for the Form and Field. Also first-class support for re-usable FieldWrap
 - [Downshift](https://github.com/paypal/downshift): Primitives to build simple, flexible, WAI-ARIA compliant enhanced input React components
 - [react-toggled](https://github.com/kentcdodds/react-toggled): Component to build simple, flexible, and accessible toggle components
 - [@navjobs/upload](https://github.com/navjobs/upload): Higher order React components for file uploading (with progress) react file upload
+- [Dayzed](https://github.com/deseretdigital/dayzed): Primitives to build simple, flexible, WAI-ARIA compliant React date-picker components
 
 ### Misc
 


### PR DESCRIPTION
Dayzed is a datepicker component that uses the render prop and prop getters patterned to help build simple, flexible, WAI-ARIA compliant date-picker components. Has bindings for both React and Preact.

Thanks!