### PR TITLE
Add @curi/react

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Awesome list of React components with render props and resources.
 ### Routing
 
 - [react-router](https://github.com/reacttraining/react-router): Declarative routing for React
+- [@curi/react](https://curi.js.org/packages/@curi/react): Centralized routing with React
 
 ### Forms
 


### PR DESCRIPTION
I have a [router project](https://curi.js.org) whose React integration uses render props.

I linked to the documentation instead of the repo because that has more information about the package, but I can flip it to the repo if you prefer.