### PR TITLE
Add react-sentinel

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ changes for the Form and Field. Also first-class support for re-usable FieldWrap
 - [react-gizmo](https://github.com/KadoBOT/react-gizmo): UI Finite State Machine for React
 - [react-geolocation](https://github.com/tkh44/react-geolocation): Declarative geolocation in React
 - [react-composer](https://github.com/jmeas/react-composer): Compose render prop components
+- [react-sentinel](https://github.com/YurkaninRyan/react-sentinel): Abstracts away requestAnimationFrame, allowing you to poll anything for props
 
 ### React Native
 


### PR DESCRIPTION
I've found a lot of libraries for things like Media Queries, Element Queries, and Animations.  At the end of the day however I found myself just writing a requestAnimationFrame loop inside my component and updating state.

`react-sentinel` Abstracts away rAF, and uses render props to allow you to easily tap into it by passing in a monitor function that works similarly to react-redux connect's `mapStateToProps`.  It automatically does a shallow comparison and only updates if the returned props are different.

You can also set the priority to low, and if your browser supports it, it will use `requestIdleCallback` instead.

Thanks!