### PR TITLE
Add react-apollo

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ changes for the Form and Field. Also first-class support for re-usable FieldWrap
 
 ### Data
 
+- [react-apollo](https://github.com/apollographql/react-apollo): ♻️ React integration for Apollo Client
 - [urql](https://github.com/FormidableLabs/urql): Universal React Query Library
 - [holen](https://github.com/tkh44/holen): Declarative fetch for React
 - [react-request](https://github.com/jmeas/react-request): Declarative HTTP requests for React with request deduplication and response caching


### PR DESCRIPTION
react-apollo has [introduced](https://dev-blog.apollodata.com/introducing-react-apollo-2-1-c837cc23d926) render-prop-based `Query` and `Mutation` components in version 2.1