### PR TITLE
Add `calendarx` to list

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Awesome list of React components with render props and resources.
 - [react-treefold](https://github.com/gnapse/react-treefold): A renderless tree component for your hierarchical React views
 - [react-useragent](https://github.com/jonstuebe/react-useragent): Retrieve user agent data through render props
 - [react-virtual-container](https://github.com/ctrlplusb/react-virtual-container): Optimise your React apps by only rendering components when in proximity to the viewport.
+- [calendarx](https://github.com/mfix22/calendarx): State container that makes creating custom calendars of all types a breeze 
 
 ### React Native
 


### PR DESCRIPTION
Thanks @jaredpalmer for curating this! Not sure if `misc` is the right category for `calendarx`, but there was no section for "view-like" state containers. The goal of `calendarx` is most similar to `downshift`, but is not an input component itself. 

Let me know what you think!